### PR TITLE
Fix Some Inconsistencies and Typos

### DIFF
--- a/src/content/docs/AirTrafficController/atc.mdx
+++ b/src/content/docs/AirTrafficController/atc.mdx
@@ -24,7 +24,7 @@ Such reliance on tool-specific implementations makes managing packages less tran
 Tools like ArgoCD rely on generic container resources (e.g., Argo Applications), which offer flexibility but introduce challenges:
 
 - Permission escalation: Users creating Argo applications, either via `kubectl` or Git commits, can bypass organizational RBAC, effectively assuming Argo's deployment permissions.
-- Underuse of Kubernetes API validation: Applications are generic and pass unchecked values to their underlying resource renderer. For example, if using helm, values are unchecked by the kubernetes api and we must rely on chart implementations to validate and surface errors later down the pipeline.
+- Underuse of Kubernetes API validation: Applications are generic and pass unchecked values to their underlying resource renderer. For example, if using helm, values are unchecked by the Kubernetes API and we must rely on chart implementations to validate and surface errors later down the pipeline.
 - Lack of specificity: Applications are deployed as generic resources, obscuring their types and requiring labels or naming conventions to organize and filter them.
 
 ## Goal of the Air Traffic Controller
@@ -77,7 +77,7 @@ First let's define a Go package containing our new Custom Resource type.
 
 Next we will want to implement a program to transform this resource into an array of resources.
 
-Note that nothing in our example implementation is specific to backends or any type of workload. For this example our package will output the backend as a kubernetes Deployment and Service.
+Note that nothing in our example implementation is specific to backends or any type of workload. For this example our package will output the backend as a Kubernetes Deployment and Service.
 
 **source:** [atc/backend/v1/flight/main.go](https://github.com/yokecd/examples/tree/main/atc/backend/v1/flight/main.go)
 

--- a/src/content/docs/Concepts/publishing.mdx
+++ b/src/content/docs/Concepts/publishing.mdx
@@ -14,7 +14,7 @@ Yoke supports three types of references:
 - http/https urls
 - oci urls
 
-Local paths are great for local development and quick interactions with your kubernetes cluster.
+Local paths are great for local development and quick interactions with your Kubernetes cluster.
 
 However there comes a time when we want to publish our flights to a shareable location.
 

--- a/src/content/docs/Examples/basics.mdx
+++ b/src/content/docs/Examples/basics.mdx
@@ -5,7 +5,7 @@ sidebar:
 ---
 
 ### Disclaimer
-- the following examples are written in Go but any language that compiles to wasm is a first class citizen for Yoke. Writing it in Go allows us to take advantage of Kubernete's core [api](https://github.com/kubernetes/api) packages. Languages that do not compile to wasm can still be used but not benefit from Yoke's asset management. For more information see [Why Wasm](/docs/concepts/wasm#why-wasm).
+- the following examples are written in Go but any language that compiles to wasm is a first class citizen for Yoke. Writing it in Go allows us to take advantage of Kubernetes' core [api](https://github.com/kubernetes/api) packages. Languages that do not compile to wasm can still be used but not benefit from Yoke's asset management. For more information see [Why Wasm](/docs/concepts/wasm#why-wasm).
 - These examples assume some familiarity with the Go toolchain, and that **yoke** has already been installed.
 
 ## Writing your first Flight

--- a/src/content/docs/Examples/configuration.mdx
+++ b/src/content/docs/Examples/configuration.mdx
@@ -5,7 +5,7 @@ sidebar:
 ---
 
 ### Disclaimer
-- the following examples are written in Go but any language that compiles to wasm is a first class citizen for Yoke. Writing it in Go allows us to take advantage of Kubernete's core [api](https://github.com/kubernetes/api) packages. Languages that do not compile to wasm can still be used but not benefit from Yoke's asset management. For more information see [Why Wasm](/docs/concepts/wasm#why-wasm).
+- the following examples are written in Go but any language that compiles to wasm is a first class citizen for Yoke. Writing it in Go allows us to take advantage of Kubernetes' core [api](https://github.com/kubernetes/api) packages. Languages that do not compile to wasm can still be used but not benefit from Yoke's asset management. For more information see [Why Wasm](/docs/concepts/wasm#why-wasm).
 - These examples assume some familiarity with the Go toolchain, and that **yoke** has already been installed.
 
 ## Flight configuration

--- a/src/content/docs/helm-compatibility.md
+++ b/src/content/docs/helm-compatibility.md
@@ -6,7 +6,7 @@ sidebar:
 
 ## Overview
 
-Although Yoke has the potential to change how we write Kubernetes Packages, as of today and for the past almost 10 years, kubernetes package management has been dominated by [Helm](https://helm.sh). Yoke has no chance of succeeding if it cannot build off of Helm and provide a migration path forward.
+Although Yoke has the potential to change how we write Kubernetes Packages, as of today and for the past almost 10 years, Kubernetes package management has been dominated by [Helm](https://helm.sh). Yoke has no chance of succeeding if it cannot build off of Helm and provide a migration path forward.
 
 At its core, a Yoke Flight is a piece of software that generates Kubernetes resources. In that way, even a Helm Chart is a subset of Flights. From that vantage point, our Flight needs to accomplish two things to be compatible with Helm:
 

--- a/src/content/docs/index.mdx
+++ b/src/content/docs/index.mdx
@@ -68,7 +68,7 @@ It consists of:
 - A server-side controller that allows you to create CustomResourceDefinitions (CRDs) to represent packages natively in Kubernetes.
 - Go packages to facilitate the transition from Helm Charts to Yoke Flights (code packages).
 
-The primary distinction between Yoke and other Kubernetes package managers, such as Helm and Timoni, lies in how Yoke describes packages. In the context of yoke packages are called **Flights** (Flights are to Yoke what Charts are to Helm). Unlike Helm and Timoni, which define packages using YAML, CUE, or other data/configuration languages, **yoke utilizes general-purpose code to describe kubernetes packages**.
+The primary distinction between Yoke and other Kubernetes package managers, such as Helm and Timoni, lies in how Yoke describes packages. In the context of yoke packages are called **Flights** (Flights are to Yoke what Charts are to Helm). Unlike Helm and Timoni, which define packages using YAML, CUE, or other data/configuration languages, **yoke utilizes general-purpose code to describe Kubernetes packages**.
 
 With yoke, **Flights are programs that generate the desired Kubernetes resources in either JSON or YAML format and output them to stdout**. Flights are typically packaged as **[WebAssembly (wasm) executables](/docs/concepts/wasm)**, with Yoke embedding Wazero, a zero-dependency wasm runtime for Go, to execute these programs.
 

--- a/src/content/docs/yokecd.md
+++ b/src/content/docs/yokecd.md
@@ -6,7 +6,7 @@ title: YokeCD
 
 The Yoke CLI is analogous to the Helm CLI. It is a client-side tool that communicates with your cluster and keeps track of packages deployed to it. However, for many, that is not how we deploy packages anymore. Where the words _Platform Engineering_ are uttered, _GitOps_ is sure to follow.
 
-To that end, we want to be able to write our Flights (programs that encapsulate a set of kubernetes packages as code) and have a continuous deployment tool, such as ArgoCD, manage our resources for us. Out of the box, ArgoCD supports Helm, Jsonnet, and Kustomize. To support more use cases, it accepts extensions via [config management plugins](https://argo-cd.readthedocs.io/en/stable/operator-manual/config-management-plugins).
+To that end, we want to be able to write our Flights (programs that encapsulate a set of Kubernetes packages as code) and have a continuous deployment tool, such as ArgoCD, manage our resources for us. Out of the box, ArgoCD supports Helm, Jsonnet, and Kustomize. To support more use cases, it accepts extensions via [config management plugins](https://argo-cd.readthedocs.io/en/stable/operator-manual/config-management-plugins).
 
 YokeCD is the official yoke config management plugin for ArgoCD. It allows you to write ArgoCD Applications but have their source evaluated by yoke's embedded wasm interpreter (wazero). The **yokecd plugin** supports a variety of setups:
 


### PR DESCRIPTION
A few small changes for consistency across docs:

- `Kubernete's` -> `Kubernetes'` (correct possessive form)
- `kubernetes` -> `Kubernetes` (just fixing inconsistent usage here)
- `api` -> `API` (also fixing inconsistent usage here)

As with https://github.com/yokecd/docs/pull/3, just stuff I noticed reading through the docs that probably jumps out more to a fresh set of eyes. Thank you for a very cool project :)